### PR TITLE
Remove hardcoding of ca.crt in templates

### DIFF
--- a/providers/conf.rb
+++ b/providers/conf.rb
@@ -35,7 +35,8 @@ action :create do
     :client_subnet_route => new_resource.client_subnet_route,
     :max_clients => new_resource.max_clients,
     :status_log => new_resource.status_log,
-    :plugins => new_resource.plugins
+    :plugins => new_resource.plugins,
+    :signing_ca_cert => new_resource.signing_ca_cert
   }
 
   template "/etc/openvpn/#{new_resource.name}.conf" do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -128,6 +128,7 @@ openvpn_conf 'server' do
   script_security node['openvpn']['script_security']
   key_dir node['openvpn']['key_dir']
   key_size node['openvpn']['key']['size']
+  signing_ca_cert node['openvpn']['signing_ca_cert'] 
   subnet node['openvpn']['subnet']
   netmask node['openvpn']['netmask']
   user node['openvpn']['user']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -128,7 +128,7 @@ openvpn_conf 'server' do
   script_security node['openvpn']['script_security']
   key_dir node['openvpn']['key_dir']
   key_size node['openvpn']['key']['size']
-  signing_ca_cert node['openvpn']['signing_ca_cert'] 
+  signing_ca_cert node['openvpn']['signing_ca_cert']
   subnet node['openvpn']['subnet']
   netmask node['openvpn']['netmask']
   user node['openvpn']['user']

--- a/recipes/users.rb
+++ b/recipes/users.rb
@@ -50,7 +50,7 @@ else
     execute "create-openvpn-tar-#{u['id']}" do
       cwd     node['openvpn']['key_dir']
       command <<-EOH
-        tar zcf #{u['id']}.tar.gz ca.crt #{u['id']}.crt #{u['id']}.key #{u['id']}.conf #{u['id']}.ovpn
+        tar zcf #{u['id']}.tar.gz File.basename(node['openvpn']['signing_ca_cert'])  #{u['id']}.crt #{u['id']}.key #{u['id']}.conf #{u['id']}.ovpn
       EOH
       not_if { ::File.exists?("#{node["openvpn"]["key_dir"]}/#{u['id']}.tar.gz") }
     end

--- a/resources/conf.rb
+++ b/resources/conf.rb
@@ -44,3 +44,4 @@ attribute :client_subnet_route, :kind_of => String
 attribute :max_clients, :kind_of => Integer
 attribute :status_log, :kind_of => String, :default => '/etc/openvpn/openvpn-status.log'
 attribute :plugins, :kind_of => Array, :default => []
+attribute :signing_ca_cert, :kind_of => String

--- a/templates/default/Rakefile.erb
+++ b/templates/default/Rakefile.erb
@@ -53,7 +53,7 @@ resolv-retry infinite
 nobind
 persist-key
 persist-tun
-ca ca.crt
+ca <%= File.basename(node['openvpn']['signing_ca_cert']) %>
 cert #{usercn}.crt
 key #{usercn}.key
 comp-lzo
@@ -71,7 +71,7 @@ EOF
   end
 
   puts "* Create .tar.gz archive for #{usercn}."
-  sh %{(cd #{keydir} && tar zcf #{usercn}.tar.gz ca.crt #{usercn}.crt #{usercn}.key #{usercn}.conf #{usercn}.ovpn)}
+  sh %{(cd #{keydir} && tar zcf #{usercn}.tar.gz <%= File.basename(node["openvpn"]["signing_ca_cert"]) %> #{usercn}.crt #{usercn}.key #{usercn}.conf #{usercn}.ovpn)}
   sh %{chmod 0600 #{keydir}/#{usercn}.tar.gz}
   tar_path = "/tmp"
   sh %{cp #{keydir}/#{usercn}.tar.gz #{tar_path}/}

--- a/templates/default/client.conf.erb
+++ b/templates/default/client.conf.erb
@@ -6,7 +6,7 @@ resolv-retry infinite
 nobind
 persist-key
 persist-tun
-ca ca.crt
+ca <%= File.basename(node['openvpn']['signing_ca_cert']) %>
 cert <%= @username %>.crt
 key <%= @username %>.key
 comp-lzo

--- a/templates/default/pkitool.erb
+++ b/templates/default/pkitool.erb
@@ -134,7 +134,7 @@ DO_ROOT="0"
 NODES_REQ="-nodes"
 NODES_P12=""
 BATCH="-batch"
-CA="ca"
+[ -n "$CA" ]  || export CA="ca"  
 # must be set or errors of openssl.cnf
 PKCS11_MODULE_PATH="dummy"
 PKCS11_PIN="dummy"

--- a/templates/default/server.conf.erb
+++ b/templates/default/server.conf.erb
@@ -42,7 +42,7 @@ route <%= @client_subnet_route %>
 <% end -%>
 
 # Keys and certificates.
-ca   <%= @key_dir %>/ca.crt
+ca   <%= @signing_ca_cert %>
 key  <%= @key_dir %>/server.key # This file should be kept secret.
 cert <%= @key_dir %>/server.crt
 dh   <%= @key_dir %>/dh<%= @key_size %>.pem

--- a/templates/default/vars.erb
+++ b/templates/default/vars.erb
@@ -66,3 +66,6 @@ export KEY_PROVINCE="<%= node['openvpn']['key']['province'] %>"
 export KEY_CITY="<%= node['openvpn']['key']['city'] %>"
 export KEY_ORG="<%= node['openvpn']['key']['org'] %>"
 export KEY_EMAIL="<%= node['openvpn']['key']['email'] %>"
+
+# Override the value of the signing key/cert (default $CA.[crt,key])  
+export CA="<%= File.basename(node['openvpn']['signing_ca_key'], ".*") %>"


### PR DESCRIPTION
Template files did not support having a different signing key
pair outside of ca.crt. This patch makes use of the 
node['openvpn']['signing_ca_cert']  attribute to update all the locations
where ca.crt was hardcoded previously.  