### PR TITLE
Support chef-solo users databag

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -49,3 +49,5 @@ default['openvpn']['key']['province']  = 'CA'
 default['openvpn']['key']['city']      = 'SanFrancisco'
 default['openvpn']['key']['org']       = 'Fort-Funston'
 default['openvpn']['key']['email']     = 'me@example.com'
+
+default['openvpn']['users_databag']    = 'users'

--- a/recipes/users.rb
+++ b/recipes/users.rb
@@ -18,41 +18,45 @@
 #
 
 if Chef::Config[:solo]
-  Chef::Log.warn 'The openvpn::users recipe requires a Chef Server, skipping.'
+  users = data_bag(node[:openvpn][:users_databag]).map { |user|
+    data_bag_item(node[:openvpn][:users_databag], user)
+  }
 else
-  search('users', '*:*') do |u|
-    execute "generate-openvpn-#{u['id']}" do
-      command "./pkitool #{u['id']}"
-      cwd     '/etc/openvpn/easy-rsa'
-      environment(
-        'EASY_RSA'     => '/etc/openvpn/easy-rsa',
-        'KEY_CONFIG'   => '/etc/openvpn/easy-rsa/openssl.cnf',
-        'KEY_DIR'      => node['openvpn']['key_dir'],
-        'CA_EXPIRE'    => node['openvpn']['key']['ca_expire'].to_s,
-        'KEY_EXPIRE'   => node['openvpn']['key']['expire'].to_s,
-        'KEY_SIZE'     => node['openvpn']['key']['size'].to_s,
-        'KEY_COUNTRY'  => node['openvpn']['key']['country'],
-        'KEY_PROVINCE' => node['openvpn']['key']['province'],
-        'KEY_CITY'     => node['openvpn']['key']['city'],
-        'KEY_ORG'      => node['openvpn']['key']['org'],
-        'KEY_EMAIL'    => node['openvpn']['key']['email']
-      )
-      not_if { ::File.exists?("#{node["openvpn"]["key_dir"]}/#{u['id']}.crt") }
-    end
+  users = search('users', '*:*')
+end
 
-    %w[conf ovpn].each do |ext|
-      template "#{node["openvpn"]["key_dir"]}/#{u['id']}.#{ext}" do
-        source   'client.conf.erb'
-        variables(:username => u['id'])
-      end
-    end
+users.each do |u|
+  execute "generate-openvpn-#{u['id']}" do
+    command "./pkitool #{u['id']}"
+    cwd     '/etc/openvpn/easy-rsa'
+    environment(
+      'EASY_RSA'     => '/etc/openvpn/easy-rsa',
+      'KEY_CONFIG'   => '/etc/openvpn/easy-rsa/openssl.cnf',
+      'KEY_DIR'      => node['openvpn']['key_dir'],
+      'CA_EXPIRE'    => node['openvpn']['key']['ca_expire'].to_s,
+      'KEY_EXPIRE'   => node['openvpn']['key']['expire'].to_s,
+      'KEY_SIZE'     => node['openvpn']['key']['size'].to_s,
+      'KEY_COUNTRY'  => node['openvpn']['key']['country'],
+      'KEY_PROVINCE' => node['openvpn']['key']['province'],
+      'KEY_CITY'     => node['openvpn']['key']['city'],
+      'KEY_ORG'      => node['openvpn']['key']['org'],
+      'KEY_EMAIL'    => node['openvpn']['key']['email']
+    )
+    not_if { ::File.exists?("#{node["openvpn"]["key_dir"]}/#{u['id']}.crt") }
+  end
 
-    execute "create-openvpn-tar-#{u['id']}" do
-      cwd     node['openvpn']['key_dir']
-      command <<-EOH
+  %w[conf ovpn].each do |ext|
+    template "#{node["openvpn"]["key_dir"]}/#{u['id']}.#{ext}" do
+      source   'client.conf.erb'
+      variables(:username => u['id'])
+    end
+  end
+
+  execute "create-openvpn-tar-#{u['id']}" do
+    cwd     node['openvpn']['key_dir']
+    command <<-EOH
         tar zcf #{u['id']}.tar.gz ca.crt #{u['id']}.crt #{u['id']}.key #{u['id']}.conf #{u['id']}.ovpn
-      EOH
-      not_if { ::File.exists?("#{node["openvpn"]["key_dir"]}/#{u['id']}.tar.gz") }
-    end
+    EOH
+    not_if { ::File.exists?("#{node["openvpn"]["key_dir"]}/#{u['id']}.tar.gz") }
   end
 end


### PR DESCRIPTION
This change lets chef-solo to run the `openvpn::users` recipe, it uses the databag and `data_bag` and `data_bag_item` as a replacement for the chef-server `search` function.

I couldn't manually test that I didn't break the chef-server function. Would very much appreciate if other users could test it or direct me into how to test it myself.