### PR TITLE
Array type attributes. Template search on cookbook

### DIFF
--- a/providers/conf.rb
+++ b/providers/conf.rb
@@ -20,7 +20,7 @@ use_inline_resources if defined?(use_inline_resources)
 
 action :create do
   template "/etc/openvpn/#{new_resource.name}.conf" do
-    cookbook 'openvpn' if !node['openvpn']['override_template']
+    cookbook 'openvpn' unless node['openvpn']['override_template']
     source 'server.conf.erb'
     owner 'root'
     group 'root'

--- a/providers/conf.rb
+++ b/providers/conf.rb
@@ -20,6 +20,7 @@ use_inline_resources if defined?(use_inline_resources)
 
 action :create do
   template "/etc/openvpn/#{new_resource.name}.conf" do
+    cookbook 'openvpn' if !node['openvpn']['override_template']
     source 'server.conf.erb'
     owner 'root'
     group 'root'

--- a/templates/default/server.conf.erb
+++ b/templates/default/server.conf.erb
@@ -6,16 +6,19 @@
 
 <% node['openvpn']['config'].sort.each do |key, value| %>
 <% next if value.nil? -%>
-<%= key %> <%=
-  case value
-  when String
-    value
-  when TrueClass
-    1
-  when FalseClass
-    0
-  else
-    value
-  end
-%>
+<% case value
+   when String %>
+<%=   key %> <%= value %>
+<% when TrueClass %>
+<%=   key %> 1
+<% when FalseClass %>
+<%=   key %> 0
+<% when Array %>
+<%    value.each do |v| %>
+<%=     v %>
+<%    end %>
+<% else %>
+<%= key %> <%= value %>
 <% end %>
+<% end %>
+


### PR DESCRIPTION
Default routes and client networks can be defined with array variables as follows: #22 #21

default['openvpn']['config']['routes']=[ "push 'route 10.5.0.0 255.255.224.0'" ]
default['openvpn']['config']['client_subnet_routes'] = [ "route 10.8.0.0 255.255.255.0", "route 10.9.1.0 255.255.255.0", "route 10.9.2.0 255.255.255.0"]