### PR TITLE
Allow configuration via hash as well as attributes

### DIFF
--- a/providers/conf.rb
+++ b/providers/conf.rb
@@ -24,6 +24,7 @@ action :create do
     owner 'root'
     group 'root'
     mode 0644
+    variables config: new_resource.config || node['openvpn']['config']
   end
 end
 

--- a/resources/conf.rb
+++ b/resources/conf.rb
@@ -20,4 +20,4 @@ actions :create, :delete
 default_action :create
 
 attribute :config,
-          kind_of: Array
+          kind_of: Hash

--- a/templates/default/server.conf.erb
+++ b/templates/default/server.conf.erb
@@ -4,7 +4,7 @@
 # Please refer to the OpenVPN documentation for details on
 # configuration settings.
 
-<% node['openvpn']['config'].sort.each do |key, value| %>
+<% @config.sort.each do |key, value| %>
 <% next if value.nil? -%>
 <%= key %> <%=
   case value


### PR DESCRIPTION
The ability to create multiple configurations on the same system is severely limited by the fact that it currently always points to the same node['openvpn']['config'] attribute. This allows a hash or some other node attribute to be given instead.

Please fix the tests. I want to be more confident about the changes I am making.