### PR TITLE
Always use openvpn cookbook for server template

### DIFF
--- a/providers/conf.rb
+++ b/providers/conf.rb
@@ -20,6 +20,7 @@ use_inline_resources if defined?(use_inline_resources)
 
 action :create do
   template "/etc/openvpn/#{new_resource.name}.conf" do
+    cookbook 'openvpn'
     source 'server.conf.erb'
     owner 'root'
     group 'root'


### PR DESCRIPTION
The nature of the template means that you wouldn't even need to use a
custom version. Resolves #21.