### PR TITLE
Changing config option name from routes to push to be valid in template

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -55,7 +55,7 @@ default['openvpn']['config']['proto']           = 'udp'
 default['openvpn']['config']['port']            = '1194'
 default['openvpn']['config']['keepalive']       = '10 120'
 default['openvpn']['config']['log']             = '/var/log/openvpn.log'
-default['openvpn']['config']['routes']          = nil
+default['openvpn']['config']['push']          = nil
 default['openvpn']['config']['script-security'] = 2
 default['openvpn']['config']['server']          = "#{node['openvpn']['subnet']} #{node['openvpn']['netmask']}"
 


### PR DESCRIPTION
Arrays are still not supported but at least we can use string to add routes

e.i.: ['openvpn']['config']['push'] = "\"route '10.0.0.0 255.0.0.0'\"" 

Is a valid entry to push 10.0.0.0/8 to your clients.