### PR TITLE
Update Serverspec for default and server recipes

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--format documentation

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,5 @@
 require 'chefspec'
 require 'chefspec/berkshelf'
+require 'serverspec'
+
+set :backend, :exec

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -2,22 +2,14 @@ require 'spec_helper'
 
 describe 'openvpn::default' do
   let(:chef_run) do
-    ChefSpec::SoloRunner.new(step_into: ['openvpn_conf']) do |node|
-      node.set['openvpn']['push_options'] = {
-        'dhcp-options' => ['DOMAIN local',
-                           'DOMAIN-SEARCH local']
-      }
-    end.converge(described_recipe)
+    ChefSpec::SoloRunner.new.converge(described_recipe)
   end
 
   it 'converges' do
     chef_run
   end
+end
 
-  it 'makes a template with dhcp options' do
-    expect(chef_run).to render_file('/etc/openvpn/server.conf')
-      .with_content('push "dhcp-options DOMAIN local"')
-    expect(chef_run).to render_file('/etc/openvpn/server.conf')
-      .with_content('push "dhcp-options DOMAIN-SEARCH local"')
-  end
+describe package('openvpn') do
+  it { should be_installed }
 end

--- a/spec/unit/recipes/server_spec.rb
+++ b/spec/unit/recipes/server_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe 'openvpn::server' do
+  let(:chef_run) do
+    ChefSpec::SoloRunner.new(step_into: ['openvpn_conf']) do |node|
+      node.set['openvpn']['push_options'] = {
+        'dhcp-options' => ['DOMAIN local',
+                           'DOMAIN-SEARCH local']
+      }
+    end.converge(described_recipe)
+  end
+
+  it 'converges' do
+    chef_run
+  end
+
+  it 'makes a template with dhcp options' do
+    expect(chef_run).to render_file('/etc/openvpn/server.conf')
+      .with_content('push "dhcp-options DOMAIN local"')
+    expect(chef_run).to render_file('/etc/openvpn/server.conf')
+      .with_content('push "dhcp-options DOMAIN-SEARCH local"')
+  end
+end


### PR DESCRIPTION
Addition for pull #48.

- add a .rspec for color/format
- add server spec to spec_helper.rb
- have the default_spec only check if the openvpn package is installed
- move default_spec to server_spec with openvpn::server recipe