### PR TITLE
Allow user to override cookbook in conf provider.

### DIFF
--- a/providers/conf.rb
+++ b/providers/conf.rb
@@ -20,7 +20,7 @@ use_inline_resources if defined?(use_inline_resources)
 
 action :create do
   template "/etc/openvpn/#{new_resource.name}.conf" do
-    cookbook 'openvpn'
+    cookbook new_resource.cookbook
     source "#{new_resource.name}.conf.erb"
     owner 'root'
     group 'root'

--- a/resources/conf.rb
+++ b/resources/conf.rb
@@ -19,5 +19,6 @@
 actions :create, :delete
 default_action :create
 
+attribute :cookbook, kind_of: String, default: 'openvpn'
 attribute :config,
           kind_of: Hash


### PR DESCRIPTION
I made the bad mistake of modifying the openvpn cookbook to set up a point-to-point VPN between two sites, which is not a use case you support.

Then I ripped all of that out and just created my own cookbook, but in the interest of laziness I just kept my old "p2p.conf.erb" template in the new cookbook.  This PR lets me use it.