### PR TITLE
Update default.rb

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -71,6 +71,7 @@ default['openvpn']['config']['push']            = nil
 default['openvpn']['config']['script-security'] = 2
 default['openvpn']['config']['persist-key']     = ''
 default['openvpn']['config']['persist-tun']     = ''
+default['openvpn']['config']['comp-lzo']        = ''
 
 default['openvpn']['config']['ca']              = node['openvpn']['signing_ca_cert']
 default['openvpn']['config']['key']             = "#{node['openvpn']['key_dir']}/server.key"


### PR DESCRIPTION
The ovpn file that is generated for each user of a data bag contains a "comp-lzo" setting. However the server.conf does not contain this setting and causes errors. Everything works correct if the server.conf also has this setting.