### PR TITLE
Generate the client configs correctly

### DIFF
--- a/templates/default/Rakefile.erb
+++ b/templates/default/Rakefile.erb
@@ -48,7 +48,7 @@ task :client do
 client
 dev tun
 proto <%= node['openvpn']['config']['proto'] %>
-remote <%= gateway %> <%= node['openvpn']['port'] %>
+remote #{gateway} <%= node['openvpn']['port'] %>
 resolv-retry infinite
 nobind
 persist-key

--- a/templates/default/Rakefile.erb
+++ b/templates/default/Rakefile.erb
@@ -47,8 +47,8 @@ task :client do
     conf = <<EOF
 client
 dev tun
-proto udp
-remote <%= node['openvpn']['gateway'] %> <%= node['openvpn']['port'] %>
+proto <%= node['openvpn']['config']['proto'] %>
+remote <%= gateway %> <%= node['openvpn']['port'] %>
 resolv-retry infinite
 nobind
 persist-key


### PR DESCRIPTION
The current client generator doesn't use the provided gateway option from the commandline, this patch fixes that. Also, the configured protocol wasn't properly set, this fixes this as well.