### PR TITLE
Ensure we truly don't overwrite an existing dh1024.pem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ openvpn Cookbook CHANGELOG
 This file is used to list changes made in each version of the openvpn cookbook.
 
 
+v2.1.2
+------
+Added a not_if on the dh1024.pem file resource
+
 v2.1.0
 ------
 Updating to use cookbook yum ~> 3.0

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'cookbooks@xhost.com.au'
 license           'Apache 2.0'
 description       'Installs and configures openvpn and includes rake tasks for managing certs.'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '2.1.1'
+version           '2.1.2'
 
 recipe 'openvpn::default',         'Installs OpenVPN only (no configuration).'
 recipe 'openvpn::install',         'Installs OpenVPN only (no configuration).'

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -87,6 +87,7 @@ unless ::File.exist?("#{key_dir}/dh#{key_size}.pem")
     owner 'root'
     group 'root'
     mode  '0600'
+    not_if { ::File.exist?("#{key_dir}/dh#{key_size}.pem") }
   end
 end
 


### PR DESCRIPTION
I have what is an unusual config where we have multiple VPN servers in various locations and would like to allow users to use the same signed certificate for each.  So, we store dh1024.pem (and other items) in encrypted data bags.  Unfortunately it was being overwritten on each run by server.rb.