### PR TITLE
Recursively create the node['openvpn']['key_dir']

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -28,6 +28,7 @@ key_size = node['openvpn']['key']['size']
 directory key_dir do
   owner 'root'
   group 'root'
+  recursive true
   mode  '0700'
 end
 


### PR DESCRIPTION
Useful when wanting to put the Key on a seperate partition (e.g. in AWS where the root volume isn't encrypted but another mount point is).

Without `recursive true` it is necessary to create parent directories to the `key_dir` path seperately, so it seems reasonable to recursively create them (equiv of `mkdir -p`)