### PR TITLE
Enable the configuring of the Message Digest used

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ The following are for the default values for fields place in the certificate fro
 * `node['openvpn']['key']['org']` - `KEY_ORG`
 * `node['openvpn']['key']['email']` - `KEY_EMAIL`
 
+The following lets you specify the message digest used for generating certificates by OpenVPN
+* `node['openvpn']['key']['message_digest'] - `sha1` . Recommend using sha256 or higher for security.
+
 
 Recipes
 -------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,6 +29,7 @@ default['openvpn']['key']['province']  = 'CA'
 default['openvpn']['key']['city']      = 'San Francisco'
 default['openvpn']['key']['org']       = 'Fort Funston'
 default['openvpn']['key']['email']     = 'admin@foobar.com'
+default['openvpn']['key']['message_digest'] = 'sha1'
 
 # Cookbook attributes
 default['openvpn']['key_dir']         = '/etc/openvpn/keys'

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -26,6 +26,7 @@ node.override['openvpn']['key']['size'] = node['openvpn']['key']['size'].to_i
 
 key_dir  = node['openvpn']['key_dir']
 key_size = node['openvpn']['key']['size']
+message_digest = node['openvpn']['key']['message_digest']
 
 directory key_dir do
   owner 'root'
@@ -97,7 +98,7 @@ bash 'openvpn-initca' do
   environment('KEY_CN' => "#{node['openvpn']['key']['org']} CA")
   code <<-EOF
     openssl req -batch -days #{node['openvpn']['key']['ca_expire']} \
-      -nodes -new -newkey rsa:#{key_size} -sha1 -x509 \
+      -nodes -new -newkey rsa:#{key_size} -#{message_digest} -x509 \
       -keyout #{node['openvpn']['signing_ca_key']} \
       -out #{node['openvpn']['signing_ca_cert']} \
       -config #{key_dir}/openssl.cnf
@@ -114,7 +115,7 @@ bash 'openvpn-server-key' do
       -config #{key_dir}/openssl.cnf && \
     openssl ca -batch -days #{node['openvpn']['key']['ca_expire']} \
       -out #{key_dir}/server.crt -in #{key_dir}/server.csr \
-      -extensions server -md sha1 -config #{key_dir}/openssl.cnf
+      -extensions server -md #{message_digest} -config #{key_dir}/openssl.cnf
   EOF
   not_if { ::File.exist?("#{key_dir}/server.crt") }
 end

--- a/templates/default/pkitool.erb
+++ b/templates/default/pkitool.erb
@@ -301,7 +301,7 @@ if [ -d "$KEY_DIR" ] && [ "$KEY_CONFIG" ]; then
 
     # Build root CA
     if [ $DO_ROOT -eq 1 ]; then
-	$OPENSSL req $BATCH -days $CA_EXPIRE $NODES_REQ -new -newkey rsa:$KEY_SIZE -sha1 \
+	$OPENSSL req $BATCH -days $CA_EXPIRE $NODES_REQ -new -newkey rsa:$KEY_SIZE -<%= node['openvpn']['key']['message_digest'] %> \
 	    -x509 -keyout "$CA.key" -out "$CA.crt" -config "$KEY_CONFIG" && \
 	    chmod 0600 "$CA.key"
     else
@@ -335,7 +335,7 @@ if [ -d "$KEY_DIR" ] && [ "$KEY_CONFIG" ]; then
 	( [ $DO_REQ -eq 0 ] || $OPENSSL req $BATCH -days $KEY_EXPIRE $NODES_REQ -new -newkey rsa:$KEY_SIZE \
 	        -keyout "$KEY_CN.key" -out "$KEY_CN.csr" $REQ_EXT -config "$KEY_CONFIG" $PKCS11_ARGS ) && \
 	    ( [ $DO_CA -eq 0 ]  || $OPENSSL ca $BATCH -days $KEY_EXPIRE -out "$KEY_CN.crt" \
-	        -in "$KEY_CN.csr" $CA_EXT -md sha1 -config "$KEY_CONFIG" ) && \
+	        -in "$KEY_CN.csr" $CA_EXT -md <%= node['openvpn']['key']['message_digest'] %> -config "$KEY_CONFIG" ) && \
 	    ( [ $DO_P12 -eq 0 ] || $OPENSSL pkcs12 -export -inkey "$KEY_CN.key" \
 	        -in "$KEY_CN.crt" -certfile "$CA.crt" -out "$KEY_CN.p12" $NODES_P12 ) && \
 	    ( [ $DO_CA -eq 0 -o $DO_P11 -eq 1 ]  || chmod 0600 "$KEY_CN.key" ) && \

--- a/test/integration/server/serverspec/server_spec.rb
+++ b/test/integration/server/serverspec/server_spec.rb
@@ -9,4 +9,11 @@ context 'Config' do
       it { is_expected.to include 'push "dhcp-option DOMAIN-SEARCH local"' }
     end
   end
+
+  describe file('/etc/openvpn/easy-rsa/pkitool') do
+    describe '#content' do
+      subject { super().content }
+      it { is_expected.to include '-md sha1' }
+    end
+  end
 end


### PR DESCRIPTION
Noticed during testing that certificates are created using sha1
message digest.
This is fine when testing, but sha1 has been demonstrated to be weak
- see `http://blog.chromium.org/2014/09/gradually-sunsetting-sha-1.html`

It seems sensible to enable the specifying of message digest algorithm
so that users can opt to use `sha256` or stronger.
