### PR TITLE
Enable the 'up' script in openvpn server config

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -70,6 +70,7 @@ default['openvpn']['config']['keepalive']       = '10 120'
 default['openvpn']['config']['log']             = '/var/log/openvpn.log'
 default['openvpn']['config']['push']            = nil
 default['openvpn']['config']['script-security'] = 2
+default['openvpn']['config']['up']              = '/etc/openvpn/server.up.sh'
 default['openvpn']['config']['persist-key']     = ''
 default['openvpn']['config']['persist-tun']     = ''
 default['openvpn']['config']['comp-lzo']        = ''


### PR DESCRIPTION
After setting some masquerading rules in `/etc/openvpn/server.up.d/myrules.sh` I found out that the openvpn server does not source the `/etc/openvpn/server.up.sh` as advertised by this cookbook.

This PR restores the functionality by setting the necessary attributes to have a `up /etc/openvpn/server.up.sh` line appear in the generated openvpn server config.