### PR TITLE
Generate CRL

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -80,6 +80,7 @@ default['openvpn']['config']['ca']              = node['openvpn']['signing_ca_ce
 default['openvpn']['config']['key']             = "#{node['openvpn']['key_dir']}/server.key"
 default['openvpn']['config']['cert']            = "#{node['openvpn']['key_dir']}/server.crt"
 default['openvpn']['config']['dh']              = "#{node['openvpn']['key_dir']}/dh#{node['openvpn']['key']['size']}.pem"
+default['openvpn']['config']['crl-verify']      = '/etc/openvpn/crl.pem'
 
 # interface configuration depending on type
 case node['openvpn']['type']

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -71,6 +71,7 @@ default['openvpn']['config']['keepalive']       = '10 120'
 default['openvpn']['config']['log']             = '/var/log/openvpn.log'
 default['openvpn']['config']['push']            = nil
 default['openvpn']['config']['script-security'] = 2
+default['openvpn']['config']['up']              = '/etc/openvpn/server.up.sh'
 default['openvpn']['config']['persist-key']     = ''
 default['openvpn']['config']['persist-tun']     = ''
 default['openvpn']['config']['comp-lzo']        = ''

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -130,6 +130,22 @@ end
   end
 end
 
+execute 'gencrl' do
+  environment('KEY_CN' => "#{node['openvpn']['key']['org']} CA")
+  command 'openssl ca -config /etc/openvpn/easy-rsa/openssl.cnf -gencrl ' \
+          "-keyfile #{node['openvpn']['key_dir']}/server.key " \
+          "-cert #{node['openvpn']['key_dir']}/server.crt " \
+          "-out #{node['openvpn']['key_dir']}/crl.pem"
+  creates "#{node['openvpn']['key_dir']}/crl.pem"
+  action  :run
+end
+
+# Make a world readable copy of the CRL
+remote_file '/etc/openvpn/crl.pem' do
+  mode   0644
+  source "file://#{node['openvpn']['key_dir']}/crl.pem"
+end
+
 openvpn_conf 'server' do
   notifies :restart, 'service[openvpn]'
   only_if { node['openvpn']['configure_default_server'] }

--- a/recipes/users.rb
+++ b/recipes/users.rb
@@ -51,7 +51,7 @@ else
     %w(conf ovpn).each do |ext|
       template "#{node['openvpn']['key_dir']}/#{u['id']}.#{ext}" do
         source 'client.conf.erb'
-        variables(username: u['id'])
+        variables(client_cn: u['id'])
       end
     end
 

--- a/spec/unit/recipes/server_spec.rb
+++ b/spec/unit/recipes/server_spec.rb
@@ -10,6 +10,7 @@ describe 'openvpn::server' do
       node.set['openvpn']['push_routes'] = [
         '192.168.10.0 255.255.255.0', '10.12.10.0 255.255.255.0'
       ]
+      # node.set['openvpn']['key']['org'] = 'testorg'
     end.converge(described_recipe)
   end
 
@@ -29,5 +30,23 @@ describe 'openvpn::server' do
       .with_content('push "route 192.168.10.0 255.255.255.0"')
     expect(chef_run).to render_file('/etc/openvpn/server.conf')
       .with_content('push "route 10.12.10.0 255.255.255.0"')
+  end
+
+  it 'executes gencrl with correction parameters' do
+    expect(chef_run).to run_execute('gencrl').with(
+      environment: { 'KEY_CN' => 'Fort Funston CA' },
+      command: 'openssl ca -config /etc/openvpn/easy-rsa/openssl.cnf -gencrl ' \
+               '-keyfile /etc/openvpn/keys/server.key ' \
+               '-cert /etc/openvpn/keys/server.crt ' \
+               '-out /etc/openvpn/keys/crl.pem',
+      creates: '/etc/openvpn/keys/crl.pem'
+    )
+  end
+
+  it 'creates a world readable CRL file' do
+    expect(chef_run).to create_remote_file('/etc/openvpn/crl.pem').with(
+      mode: 0644,
+      source: 'file:///etc/openvpn/keys/crl.pem'
+    )
   end
 end

--- a/test/integration/server/serverspec/server_spec.rb
+++ b/test/integration/server/serverspec/server_spec.rb
@@ -16,4 +16,20 @@ context 'Config' do
       it { is_expected.to include '-md sha256' }
     end
   end
+
+  describe file('/etc/openvpn/keys/crl.pem') do
+    describe '#content' do
+      subject { super().content }
+    end
+    it { is_expected.to be_file }
+  end
+
+  describe command('openssl crl -in /etc/openvpn/keys/crl.pem -noout -issuer') do
+    its(:stdout) do
+      is_expected.to eq(
+        'issuer=/C=US/ST=CA/L=San Francisco/O=Fort Funston/OU=OpenVPN ' \
+        "Server/CN=server/emailAddress=admin@foobar.com\n"
+      )
+    end
+  end
 end

--- a/test/integration/server/serverspec/server_spec.rb
+++ b/test/integration/server/serverspec/server_spec.rb
@@ -2,6 +2,11 @@
 require 'spec_helper'
 
 context 'Config' do
+  describe service('openvpn') do
+    it { is_expected.to be_enabled }
+    it { is_expected.to be_running }
+  end
+
   describe file('/etc/openvpn/server.conf') do
     describe '#content' do
       subject { super().content }


### PR DESCRIPTION
It's helpful to have the OpenVPN cookbook do this work because if `/etc/openvpn/server.conf` references a CRL that does not yet exist, the entire converge blows up. Normally this would be solved by "pre-seeding" the file with a wrapper cookbook, but in order to generate a CRL you need the openssl.cnf file that this cookbook creates.