### PR TITLE
Added dhcp-option to push DNS servers

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -67,4 +67,6 @@ if node['openvpn']['type'] == 'server-bridge'
   default['openvpn']['config']['dev'] = 'tap0'
 else
   default['openvpn']['config']['dev'] = 'tun0'
+  default['openvpn']['config']['push-option']['dhcp-option']['DNS']	=	'10.64.6.18'
+  default['openvpn']['config']['push-option']['dhcp-option']['DNS']	=	'10.64.6.22'
 end


### PR DESCRIPTION
Attempting to have the openvpn server push vox internal DNS servers with client connections.