### PR TITLE
Fix fedora systemd service

### DIFF
--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -31,14 +31,10 @@ when 'rhel'
     service_name = 'openvpn'
   end
 when 'fedora'
-  if node['platform_version'] >= '22'
     link "/etc/systemd/system/multi-user.target.wants/openvpn@#{node['openvpn']['type']}.service" do
       to '/usr/lib/systemd/system/openvpn@.service'
     end
     service_name = "openvpn@#{node['openvpn']['type']}.service"
-  else
-    service_name = 'openvpn'
-  end
 when 'arch'
   service_name = "openvpn@#{node['openvpn']['type']}.service"
 else

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -30,6 +30,15 @@ when 'rhel'
   else
     service_name = 'openvpn'
   end
+when 'fedora'
+  if node['platform_version'] >= '22'
+    link "/etc/systemd/system/multi-user.target.wants/openvpn@#{node['openvpn']['type']}.service" do
+      to '/usr/lib/systemd/system/openvpn@.service'
+    end
+    service_name = "openvpn@#{node['openvpn']['type']}.service"
+  else
+    service_name = 'openvpn'
+  end
 when 'arch'
   service_name = "openvpn@#{node['openvpn']['type']}.service"
 else


### PR DESCRIPTION
Using the 3.0.x cookbook on Fedora 24 fails to install the systemd service files correctly since Fedora is in it's own platform_family per https://github.com/chef/ohai/blob/master/lib/ohai/plugins/linux/platform.rb#L191-L194. This PR addresses this issue.