### PR TITLE
Allow override of global push settings

### DIFF
--- a/providers/conf.rb
+++ b/providers/conf.rb
@@ -27,8 +27,8 @@ action :create do
     mode 0644
     variables(
       config: new_resource.config || node['openvpn']['config'],
-      push_routes: node['openvpn']['push_routes'],
-      push_options: node['openvpn']['push_options'],
+      push_routes: new_resource.push_routes || node['openvpn']['push_routes'],
+      push_options: new_resource.push_options || node['openvpn']['push_options'],
       client_cn: node['openvpn']['client_cn']
     )
     helpers do

--- a/resources/conf.rb
+++ b/resources/conf.rb
@@ -22,3 +22,7 @@ default_action :create
 attribute :cookbook, kind_of: String, default: 'openvpn'
 attribute :config,
           kind_of: Hash
+attribute :push_routes,
+          kind_of: Hash
+attribute :push_options,
+          kind_of: Hash


### PR DESCRIPTION
We run multiple openvpn instances, some needing `push_options` that differ from the `node[openvpn][push_options]` value.  This change allows overriding the global setting per-instance

Example
```ruby
  openvpn_conf 'something' do
    action :create
    config ({
      'opt-verify' => '',
      'verb' => '4'
    })
    push_options ({
      'explicit-exit-notify' => '1',
      'route-gateway' => '10.8.0.1'
    })
  end
```